### PR TITLE
Update simulated-alexa-switch.groovy

### DIFF
--- a/devicetypes/bjpierron/simulated-alexa-switch.src/simulated-alexa-switch.groovy
+++ b/devicetypes/bjpierron/simulated-alexa-switch.src/simulated-alexa-switch.groovy
@@ -13,7 +13,7 @@
  */
 metadata {
 
-    definition (name: "Simulated Alexa Switch", namespace: "bjpierron", author: "bjpierron") {
+    definition (name: "Simulated Alexa Switch-Contact", namespace: "bjpierron", author: "bjpierron") {
         capability "Switch"
         capability "Sensor"
         capability "Actuator"


### PR DESCRIPTION
Minor name tweaks to avoid confusion with other 'ordinary' virtual/simulated devices